### PR TITLE
Add support for application data versioning

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,12 @@
+--binarygrouping none
+--decimalgrouping none
+--exclude Pods, Package.swift, Tests/TextMarkupKitTests/TestStrings.swift
+--header "//  Licensed to the Apache Software Foundation (ASF) under one\n//  or more contributor license agreements.  See the NOTICE file\n//  distributed with this work for additional information\n//  regarding copyright ownership.  The ASF licenses this file\n//  to you under the Apache License, Version 2.0 (the\n//  \"License\"); you may not use this file except in compliance\n//  with the License.  You may obtain a copy of the License at\n//\n//  http://www.apache.org/licenses/LICENSE-2.0\n//\n//  Unless required by applicable law or agreed to in writing,\n//  software distributed under the License is distributed on an\n//  \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY\n//  KIND, either express or implied.  See the License for the\n//  specific language governing permissions and limitations\n//  under the License."
+--hexgrouping none
+--indent 2
+--octalgrouping none
+--patternlet inline
+--stripunusedargs closure-only
+--wraparguments beforefirst
+--wrapcollections beforefirst
+--self init-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.2.0] - 2021-10-02
+
+### Added
+
+This version adds the concept of "application data versioning." You are STRONGLY encouraged to add an application identifier and application version to file formats built with KeyValueCRDT. This will prevent old versions of your software from corrupting data written by new versions of your software.
+
 ## [1.1.0] - 2021-09-30
 
 ### Added

--- a/Sources/KeyValueCRDT/ApplicationIdentifier.swift
+++ b/Sources/KeyValueCRDT/ApplicationIdentifier.swift
@@ -1,4 +1,19 @@
-// 
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
 
 import Foundation
 import GRDB
@@ -75,4 +90,3 @@ internal extension ApplicationDataUpgrader {
     }
   }
 }
-

--- a/Sources/KeyValueCRDT/ApplicationIdentifier.swift
+++ b/Sources/KeyValueCRDT/ApplicationIdentifier.swift
@@ -1,0 +1,59 @@
+// 
+
+import Foundation
+import GRDB
+
+/// Stores information about the application that created the key-value store.
+public struct ApplicationIdentifier: Codable, Comparable {
+  public init(applicationIdentifier: String, majorVersion: Int, minorVersion: Int, applicationDescription: String? = nil) {
+    self.applicationIdentifier = applicationIdentifier
+    self.majorVersion = majorVersion
+    self.minorVersion = minorVersion
+    self.applicationDescription = applicationDescription
+  }
+
+  /// Application identifier, in reverse-DNS. Primary key of this table.
+  var applicationIdentifier: String
+
+  /// Major version number of the file format.
+  var majorVersion: Int
+
+  /// Minor version number of the file format.
+  var minorVersion: Int
+
+  /// Optional application description.
+  var applicationDescription: String?
+
+  public static func < (lhs: ApplicationIdentifier, rhs: ApplicationIdentifier) -> Bool {
+    (lhs.applicationIdentifier, lhs.majorVersion, lhs.minorVersion) < (rhs.applicationIdentifier, rhs.majorVersion, rhs.minorVersion)
+  }
+
+  public enum ComparisonResult {
+    case compatible
+    case incompatible
+    case requiresUpgrade
+    case currentVersionIsTooOld
+  }
+
+  public func compare(to other: ApplicationIdentifier?) -> ComparisonResult {
+    guard let other = other else {
+      return .requiresUpgrade
+    }
+    if applicationIdentifier != other.applicationIdentifier {
+      return .incompatible
+    }
+    if other.majorVersion > majorVersion {
+      return .currentVersionIsTooOld
+    }
+    if (majorVersion, minorVersion) > (other.majorVersion, other.minorVersion) {
+      return .requiresUpgrade
+    } else {
+      return .compatible
+    }
+  }
+}
+
+// TODO: Is there a way to keep the "this is a database record" private without creating another type?
+extension ApplicationIdentifier: FetchableRecord, PersistableRecord {
+  public static let databaseTableName = "applicationIdentifier"
+}

--- a/Sources/KeyValueCRDT/AuthorRecord.swift
+++ b/Sources/KeyValueCRDT/AuthorRecord.swift
@@ -1,9 +1,19 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
 //
-//  File.swift
-//  File
+//  http://www.apache.org/licenses/LICENSE-2.0
 //
-//  Created by Brian Dewey on 7/19/21.
-//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
 
 import Foundation
 import GRDB
@@ -20,4 +30,3 @@ internal struct AuthorRecord: Codable, FetchableRecord, PersistableRecord {
     static let id = Column(AuthorRecord.CodingKeys.id)
   }
 }
-

--- a/Sources/KeyValueCRDT/DatabaseMigrator+CRDT.swift
+++ b/Sources/KeyValueCRDT/DatabaseMigrator+CRDT.swift
@@ -59,7 +59,7 @@ internal extension DatabaseMigrator {
     }
     migrator.registerMigration("applicationIdentifier") { db in
       try db.create(table: ApplicationIdentifier.databaseTableName, body: { td in
-        td.column("applicationIdentifier", .text).primaryKey()
+        td.column("id", .text).primaryKey()
         td.column("majorVersion", .integer).notNull()
         td.column("minorVersion", .integer).notNull()
         td.column("applicationDescription", .text)

--- a/Sources/KeyValueCRDT/DatabaseMigrator+CRDT.swift
+++ b/Sources/KeyValueCRDT/DatabaseMigrator+CRDT.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import GRDB
 
 internal extension DatabaseMigrator {

--- a/Sources/KeyValueCRDT/DatabaseMigrator+CRDT.swift
+++ b/Sources/KeyValueCRDT/DatabaseMigrator+CRDT.swift
@@ -57,6 +57,14 @@ internal extension DatabaseMigrator {
         td.add(column: "timestamp", .datetime)
       })
     }
+    migrator.registerMigration("applicationIdentifier") { db in
+      try db.create(table: ApplicationIdentifier.databaseTableName, body: { td in
+        td.column("applicationIdentifier", .text).primaryKey()
+        td.column("majorVersion", .integer).notNull()
+        td.column("minorVersion", .integer).notNull()
+        td.column("applicationDescription", .text)
+      })
+    }
     return migrator
   }()
 }

--- a/Sources/KeyValueCRDT/DatabasePool+CRDT.swift
+++ b/Sources/KeyValueCRDT/DatabasePool+CRDT.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 import GRDB
 

--- a/Sources/KeyValueCRDT/DatabaseQueue+CRDT.swift
+++ b/Sources/KeyValueCRDT/DatabaseQueue+CRDT.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 import GRDB
 

--- a/Sources/KeyValueCRDT/EntryRecord.swift
+++ b/Sources/KeyValueCRDT/EntryRecord.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 import GRDB
 
@@ -57,7 +74,7 @@ internal struct EntryRecord: Codable, FetchableRecord, PersistableRecord {
       case .json(let json):
         self.json = json
       case .blob(let mimeType, let blob):
-        self.blobMimeType = mimeType
+        blobMimeType = mimeType
         self.blob = blob
       case .null:
         break

--- a/Sources/KeyValueCRDT/KeyValueCRDTError.swift
+++ b/Sources/KeyValueCRDT/KeyValueCRDTError.swift
@@ -4,6 +4,12 @@ public enum KeyValueCRDTError: Error {
   /// The CRDT database has a new version schema that this version does not understand.
   case databaseSchemaTooNew
 
+  /// The CRDT database has application data stored in a new version format that this version does not understand.
+  case applicationDataTooNew
+
+  /// The CRDT database has application data that comes from another application.
+  case incompatibleApplications
+
   /// There are conflicting versions of a value in a code path that asserted there should be only one.
   case versionConflict
 
@@ -12,4 +18,7 @@ public enum KeyValueCRDTError: Error {
 
   /// Something's wrong with the author table.
   case authorTableInconsistency
+
+  case mergeSourceIncompatible
+  case mergeSourceRequiresUpgrade
 }

--- a/Sources/KeyValueCRDT/KeyValueCRDTError.swift
+++ b/Sources/KeyValueCRDT/KeyValueCRDTError.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 
 public enum KeyValueCRDTError: Error {

--- a/Sources/KeyValueCRDT/KeyValueDatabase.swift
+++ b/Sources/KeyValueCRDT/KeyValueDatabase.swift
@@ -28,24 +28,6 @@ public protocol ApplicationDataUpgrader {
   func upgradeApplicationData(in database: KeyValueDatabase) throws
 }
 
-private extension ApplicationDataUpgrader {
-  func upgrade(database: KeyValueDatabase) throws {
-    let comparisonResult = expectedApplicationIdentifier.compare(to: try database.applicationIdentifier)
-    switch comparisonResult {
-    case .compatible:
-      // nothing to do
-      break
-    case .incompatible:
-      throw KeyValueCRDTError.incompatibleApplications
-    case .requiresUpgrade:
-      try upgradeApplicationData(in: database)
-      try database.setApplicationIdentifier(expectedApplicationIdentifier)
-    case .currentVersionIsTooOld:
-      throw KeyValueCRDTError.applicationDataTooNew
-    }
-  }
-}
-
 /// Implements a key/value CRDT backed by a single sqlite database.
 ///
 /// `KeyValueDatabase` provides a *scoped* key/value storage backed by a single sqlite database. The database is a *conflict-free replicated data type* (CRDT), meaning
@@ -480,7 +462,7 @@ JOIN entryFullText ON entryFullText.rowId = entry.rowId AND entryFullText MATCH 
     if let applicationIdentifier = try self.applicationIdentifier,
        let otherApplicationIdentifier = try source.applicationIdentifier {
       switch applicationIdentifier.compare(to: otherApplicationIdentifier) {
-      case .currentVersionIsTooOld, .incompatible, .requiresUpgrade:
+      case .currentVersionIsTooOld, .incompatible:
         throw KeyValueCRDTError.mergeSourceIncompatible
       case .requiresUpgrade:
         throw KeyValueCRDTError.mergeSourceRequiresUpgrade

--- a/Sources/KeyValueCRDT/Resolver.swift
+++ b/Sources/KeyValueCRDT/Resolver.swift
@@ -1,4 +1,19 @@
-// Copyright (c) 2018-2021  Brian Dewey. Covered by the Apache 2.0 license.
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
 
 import Foundation
 
@@ -15,13 +30,13 @@ public struct LastWriterWinsResolver: Resolver {
   }
 }
 
-extension Resolver where Self == LastWriterWinsResolver {
-  public static var lastWriterWins: LastWriterWinsResolver { LastWriterWinsResolver() }
+public extension Resolver where Self == LastWriterWinsResolver {
+  static var lastWriterWins: LastWriterWinsResolver { LastWriterWinsResolver() }
 }
 
-extension Array where Element == Version {
+public extension Array where Element == Version {
   /// Picks a single value from the version array using `resolver`.
-  public func resolved(with resolver: Resolver) -> Value? {
+  func resolved(with resolver: Resolver) -> Value? {
     resolver.resolveVersions(self)
   }
 }

--- a/Sources/KeyValueCRDT/ScopedKey.swift
+++ b/Sources/KeyValueCRDT/ScopedKey.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 
 /// A scope/key pair.

--- a/Sources/KeyValueCRDT/Statistics.swift
+++ b/Sources/KeyValueCRDT/Statistics.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 
 /// Information about the number of entries in the database.

--- a/Sources/KeyValueCRDT/TombstoneRecord.swift
+++ b/Sources/KeyValueCRDT/TombstoneRecord.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 import GRDB
 

--- a/Sources/KeyValueCRDT/UIKeyValueDocument.swift
+++ b/Sources/KeyValueCRDT/UIKeyValueDocument.swift
@@ -1,250 +1,268 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 #if os(iOS)
 
-import Combine
-import GRDB
-import Logging
-import UIKit
+  import Combine
+  import GRDB
+  import Logging
+  import UIKit
 
-private extension Logger {
-  static let keyValueDocument: Logger = {
-    var logger = Logger(label: "org.brians-brain.KeyValueCRDT.UIKeyValueDocument")
-    logger.logLevel = .debug
-    return logger
-  }()
-}
-
-public protocol UIKeyValueDocumentDelegate: AnyObject {
-  /// Called before using ``KeyValueCRDT/KeyValueDatabase/merge(source:)`` to merge **conflicting** copies of the CRDT.
-  ///
-  /// This is a useful hook for making backup copies of the CRDT in case something goes wrong!
-  func keyValueDocument(_ document: UIKeyValueDocument, willMergeCRDT sourceCRDT: KeyValueDatabase, into destinationCRDT: KeyValueDatabase)
-}
-
-private struct UpgraderWrapper: ApplicationDataUpgrader {
-  let upgrader: ApplicationDataUpgrader
-  let document: UIKeyValueDocument
-
-  init?(_ upgrader: ApplicationDataUpgrader?, document: UIKeyValueDocument) {
-    guard let upgrader = upgrader else {
-      return nil
-    }
-    self.upgrader = upgrader
-    self.document = document
+  private extension Logger {
+    static let keyValueDocument: Logger = {
+      var logger = Logger(label: "org.brians-brain.KeyValueCRDT.UIKeyValueDocument")
+      logger.logLevel = .debug
+      return logger
+    }()
   }
 
-  var expectedApplicationIdentifier: ApplicationIdentifier { upgrader.expectedApplicationIdentifier }
-
-  func upgradeApplicationData(in database: KeyValueDatabase) throws {
-    try upgrader.upgradeApplicationData(in: database)
-    document.updateChangeCount(.done)
-    Logger.keyValueDocument.info("Upgraded data in database to version \(expectedApplicationIdentifier)")
-  }
-}
-
-/// A UIDocument subclass that provides access to a key-value CRDT database.
-///
-/// Because it is a `UIDocument` subclass, it interoperates with the iOS mechanisms for coordinating access to files via `NSFileCoordinator` and `NSFilePresenter`.
-/// This lets you use a `UIKeyValueDocument` for documents that will be stored in iCloud Documents, among other places.
-///
-/// In iOS, successfully working with services like iCloud involves careful coordination of I/O with other services, and natively sqlite does not know how to do this.
-/// Therefore, `UIKeyValueDocument` reads the entire database into memory, works on the in-memory copy, and writes the entire database to disk when it needs to
-/// coordinate with other proceses. Therefore, you should exclusively use `UIKeyValueDocument` for "document-sized" purposes, where reading/writing the entire
-/// document is feasible. If you do not want to read the entire contents of a key/value CRDT into memory at once, you should work directly with ``KeyValueDatabase``.
-/// ``KeyValueDatabase`` loads data on-demand but does not interoperate with the document replication mechanisms in iOS.
-public final class UIKeyValueDocument: UIDocument {
-  /// Designated initializer.
-  ///
-  /// - parameter fileURL: The URL for the key-value CRDT database.
-  /// - parameter author: An ``Author`` struct that identifies all changes made by this instance.
-  public init(fileURL: URL, authorDescription: String, upgrader: ApplicationDataUpgrader? = nil) throws {
-    self.authorDescription = authorDescription
-    self.upgrader = upgrader
-    super.init(fileURL: fileURL)
+  public protocol UIKeyValueDocumentDelegate: AnyObject {
+    /// Called before using ``KeyValueCRDT/KeyValueDatabase/merge(source:)`` to merge **conflicting** copies of the CRDT.
+    ///
+    /// This is a useful hook for making backup copies of the CRDT in case something goes wrong!
+    func keyValueDocument(_ document: UIKeyValueDocument, willMergeCRDT sourceCRDT: KeyValueDatabase, into destinationCRDT: KeyValueDatabase)
   }
 
-  public weak var delegate: UIKeyValueDocumentDelegate?
+  private struct UpgraderWrapper: ApplicationDataUpgrader {
+    let upgrader: ApplicationDataUpgrader
+    let document: UIKeyValueDocument
 
-  /// A human-readable hint identifying the author of any changes made from this instance.
-  public let authorDescription: String
-
-  public let upgrader: ApplicationDataUpgrader?
-
-  /// The key-value CRDT stored in the document.
-  ///
-  /// This value is `nil` upon creating a document and will be non-nil after opening it.
-  public private(set) var keyValueCRDT: KeyValueDatabase?
-
-  /// Pipeline for monitoring for unsaved changes to the in-memory database.
-  private var hasUnsavedChangesPipeline: AnyCancellable?
-
-  public override func open(completionHandler: ((Bool) -> Void)? = nil) {
-    Logger.keyValueDocument.info("Opening \(fileURL.path)")
-    super.open { success in
-      Logger.keyValueDocument.info("Opened '\(self.fileURL.path)' -- success = \(success) state = \(self.documentState)")
-      NotificationCenter.default.addObserver(
-        self,
-        selector: #selector(self.handleDocumentStateChanged),
-        name: UIDocument.stateChangedNotification,
-        object: self
-      )
-      if self.keyValueCRDT != nil {
-        self.startMonitoringChanges()
+    init?(_ upgrader: ApplicationDataUpgrader?, document: UIKeyValueDocument) {
+      guard let upgrader = upgrader else {
+        return nil
       }
-      self.handleDocumentStateChanged()
-      completionHandler?(success)
+      self.upgrader = upgrader
+      self.document = document
+    }
+
+    var expectedApplicationIdentifier: ApplicationIdentifier { upgrader.expectedApplicationIdentifier }
+
+    func upgradeApplicationData(in database: KeyValueDatabase) throws {
+      try upgrader.upgradeApplicationData(in: database)
+      document.updateChangeCount(.done)
+      Logger.keyValueDocument.info("Upgraded data in database to version \(expectedApplicationIdentifier)")
     }
   }
 
-  public override func close(completionHandler: ((Bool) -> Void)? = nil) {
-    // Remove-on-deinit doesn't apply to UIDocument, it seems to me. These have an explicit open/close lifecycle.
-    Logger.keyValueDocument.info("Closing \(fileURL.path)")
-    stopMonitoringChanges()
-    NotificationCenter.default.removeObserver(self) // swiftlint:disable:this notification_center_detachment
-    super.close(completionHandler: completionHandler)
-  }
-
-  public override func save(to url: URL, for saveOperation: UIDocument.SaveOperation, completionHandler: ((Bool) -> Void)? = nil) {
-    Logger.keyValueDocument.info("Saving \(url.path)")
-    super.save(to: url, for: saveOperation) { success in
-      Logger.keyValueDocument.info("Save finished. Success = \(success)")
-      completionHandler?(success)
+  /// A UIDocument subclass that provides access to a key-value CRDT database.
+  ///
+  /// Because it is a `UIDocument` subclass, it interoperates with the iOS mechanisms for coordinating access to files via `NSFileCoordinator` and `NSFilePresenter`.
+  /// This lets you use a `UIKeyValueDocument` for documents that will be stored in iCloud Documents, among other places.
+  ///
+  /// In iOS, successfully working with services like iCloud involves careful coordination of I/O with other services, and natively sqlite does not know how to do this.
+  /// Therefore, `UIKeyValueDocument` reads the entire database into memory, works on the in-memory copy, and writes the entire database to disk when it needs to
+  /// coordinate with other proceses. Therefore, you should exclusively use `UIKeyValueDocument` for "document-sized" purposes, where reading/writing the entire
+  /// document is feasible. If you do not want to read the entire contents of a key/value CRDT into memory at once, you should work directly with ``KeyValueDatabase``.
+  /// ``KeyValueDatabase`` loads data on-demand but does not interoperate with the document replication mechanisms in iOS.
+  public final class UIKeyValueDocument: UIDocument {
+    /// Designated initializer.
+    ///
+    /// - parameter fileURL: The URL for the key-value CRDT database.
+    /// - parameter author: An ``Author`` struct that identifies all changes made by this instance.
+    public init(fileURL: URL, authorDescription: String, upgrader: ApplicationDataUpgrader? = nil) throws {
+      self.authorDescription = authorDescription
+      self.upgrader = upgrader
+      super.init(fileURL: fileURL)
     }
-  }
 
-  public override func read(from url: URL) throws {
-    Logger.keyValueDocument.info("Reading from \(url.path)")
-    stopMonitoringChanges()
-    do {
-      let onDiskDataQueue = try memoryDatabaseQueue(fileURL: url)
-      let wrappedUpgrader = UpgraderWrapper(upgrader, document: self)
-      let onDiskData = try KeyValueDatabase(databaseWriter: onDiskDataQueue, authorDescription: authorDescription, upgrader: wrappedUpgrader)
-      if let keyValueCRDT = keyValueCRDT {
-        if try keyValueCRDT.dominates(other: onDiskData) {
-          Logger.keyValueDocument.info("Ignoring read from \(url.path) because it contains no new information")
-        } else {
-          // Neither dominate. Merge disk contents into memory.
-          Logger.keyValueDocument.info("Merging contents of \(url.path) with in-memory data")
-          let changedEntries = try keyValueCRDT.merge(source: onDiskData)
-          Logger.keyValueDocument.info("Updated keys from merge: \(changedEntries.count)")
+    public weak var delegate: UIKeyValueDocumentDelegate?
+
+    /// A human-readable hint identifying the author of any changes made from this instance.
+    public let authorDescription: String
+
+    public let upgrader: ApplicationDataUpgrader?
+
+    /// The key-value CRDT stored in the document.
+    ///
+    /// This value is `nil` upon creating a document and will be non-nil after opening it.
+    public private(set) var keyValueCRDT: KeyValueDatabase?
+
+    /// Pipeline for monitoring for unsaved changes to the in-memory database.
+    private var hasUnsavedChangesPipeline: AnyCancellable?
+
+    override public func open(completionHandler: ((Bool) -> Void)? = nil) {
+      Logger.keyValueDocument.info("Opening \(fileURL.path)")
+      super.open { success in
+        Logger.keyValueDocument.info("Opened '\(self.fileURL.path)' -- success = \(success) state = \(self.documentState)")
+        NotificationCenter.default.addObserver(
+          self,
+          selector: #selector(self.handleDocumentStateChanged),
+          name: UIDocument.stateChangedNotification,
+          object: self
+        )
+        if self.keyValueCRDT != nil {
+          self.startMonitoringChanges()
         }
-      } else {
-        Logger.keyValueDocument.info("Loading initial copy of database into memory")
-        self.keyValueCRDT = onDiskData
+        self.handleDocumentStateChanged()
+        completionHandler?(success)
       }
-      startMonitoringChanges()
-    } catch {
-      Logger.keyValueDocument.error("Error opening \(url.path): \(error)")
-      throw error
     }
-  }
 
-  override public func writeContents(
-    _ contents: Any,
-    to url: URL,
-    for saveOperation: UIDocument.SaveOperation,
-    originalContentsURL: URL?
-  ) throws {
-    guard hasUnsavedChanges else {
-      return
+    override public func close(completionHandler: ((Bool) -> Void)? = nil) {
+      // Remove-on-deinit doesn't apply to UIDocument, it seems to me. These have an explicit open/close lifecycle.
+      Logger.keyValueDocument.info("Closing \(fileURL.path)")
+      stopMonitoringChanges()
+      NotificationCenter.default.removeObserver(self) // swiftlint:disable:this notification_center_detachment
+      super.close(completionHandler: completionHandler)
     }
-    Logger.keyValueDocument.info("document state \(documentState): Writing content to '\(url.path)'")
-    try keyValueCRDT?.save(to: url)
-    Logger.keyValueDocument.debug("document save finished")
-  }
-}
 
-// MARK: - Private
-private extension UIKeyValueDocument {
-  @objc func handleDocumentStateChanged() {
-    guard documentState.contains(.inConflict), let keyValueCRDT = keyValueCRDT else {
-      return
-    }
-    Logger.keyValueDocument.info("Handling conflict")
-    do {
-      for conflictVersion in NSFileVersion.unresolvedConflictVersionsOfItem(at: fileURL) ?? [] {
-        let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("kvcrdt")
-        try conflictVersion.replaceItem(at: tempURL, options: [])
-        defer {
-          try? FileManager.default.removeItem(at: tempURL)
-        }
-        let conflictQueue = try memoryDatabaseQueue(fileURL: tempURL)
-        let conflictCRDT = try KeyValueDatabase(databaseWriter: conflictQueue, authorDescription: authorDescription)
-        delegate?.keyValueDocument(self, willMergeCRDT: conflictCRDT, into: keyValueCRDT)
-        let updates = try keyValueCRDT.merge(source: conflictCRDT)
-        Logger.keyValueDocument.info("UIDocument: Merged conflict version: \(conflictVersion). Updates = \(updates)")
-        conflictVersion.isResolved = true
-        try conflictVersion.remove()
+    override public func save(to url: URL, for saveOperation: UIDocument.SaveOperation, completionHandler: ((Bool) -> Void)? = nil) {
+      Logger.keyValueDocument.info("Saving \(url.path)")
+      super.save(to: url, for: saveOperation) { success in
+        Logger.keyValueDocument.info("Save finished. Success = \(success)")
+        completionHandler?(success)
       }
-      Logger.keyValueDocument.info("UIDocument: Finished resolving conflicts")
-      try NSFileVersion.removeOtherVersionsOfItem(at: fileURL)
-    } catch {
-      Logger.keyValueDocument.error("UIDocument: Unexpected error resolving conflict: \(error)")
     }
-  }
 
-  /// Creates an in-memory database queue for the contents of the file at `fileURL`
-  /// - note: If fileURL does not exist, this method returns an empty database queue.
-  /// - parameter fileURL: The file URL to read.
-  /// - returns: An in-memory database queue with the contents of fileURL.
-  func memoryDatabaseQueue(fileURL: URL) throws -> DatabaseQueue {
-    let coordinator = NSFileCoordinator(filePresenter: self)
-    var coordinatorError: NSError?
-    var result: Result<DatabaseQueue, Swift.Error>?
-    coordinator.coordinate(readingItemAt: fileURL, options: [], error: &coordinatorError) { coordinatedURL in
-      result = Result {
-        let queue = try DatabaseQueue(path: ":memory:")
-        do {
-          let didGetAccess = coordinatedURL.startAccessingSecurityScopedResource()
-          defer {
-            if didGetAccess {
-              coordinatedURL.stopAccessingSecurityScopedResource()
-            }
+    override public func read(from url: URL) throws {
+      Logger.keyValueDocument.info("Reading from \(url.path)")
+      stopMonitoringChanges()
+      do {
+        let onDiskDataQueue = try memoryDatabaseQueue(fileURL: url)
+        let wrappedUpgrader = UpgraderWrapper(upgrader, document: self)
+        let onDiskData = try KeyValueDatabase(databaseWriter: onDiskDataQueue, authorDescription: authorDescription, upgrader: wrappedUpgrader)
+        if let keyValueCRDT = keyValueCRDT {
+          if try keyValueCRDT.dominates(other: onDiskData) {
+            Logger.keyValueDocument.info("Ignoring read from \(url.path) because it contains no new information")
+          } else {
+            // Neither dominate. Merge disk contents into memory.
+            Logger.keyValueDocument.info("Merging contents of \(url.path) with in-memory data")
+            let changedEntries = try keyValueCRDT.merge(source: onDiskData)
+            Logger.keyValueDocument.info("Updated keys from merge: \(changedEntries.count)")
           }
-          let fileQueue = try DatabaseQueue(path: coordinatedURL.path)
-          try fileQueue.backup(to: queue)
-        } catch {
-          Logger.keyValueDocument.info("Unable to load \(coordinatedURL.path): \(error)")
+        } else {
+          Logger.keyValueDocument.info("Loading initial copy of database into memory")
+          keyValueCRDT = onDiskData
         }
-        return queue
+        startMonitoringChanges()
+      } catch {
+        Logger.keyValueDocument.error("Error opening \(url.path): \(error)")
+        throw error
       }
     }
 
-    if let coordinatorError = coordinatorError {
-      throw coordinatorError
-    }
-
-    switch result {
-    case .failure(let error):
-      throw error
-    case .success(let dbQueue):
-      return dbQueue
-    case .none:
-      preconditionFailure()
+    override public func writeContents(
+      _ contents: Any,
+      to url: URL,
+      for saveOperation: UIDocument.SaveOperation,
+      originalContentsURL: URL?
+    ) throws {
+      guard hasUnsavedChanges else {
+        return
+      }
+      Logger.keyValueDocument.info("document state \(documentState): Writing content to '\(url.path)'")
+      try keyValueCRDT?.save(to: url)
+      Logger.keyValueDocument.debug("document save finished")
     }
   }
 
-  func startMonitoringChanges() {
-    guard let keyValueCRDT = keyValueCRDT else {
-      assertionFailure()
-      return
+  // MARK: - Private
+
+  private extension UIKeyValueDocument {
+    @objc func handleDocumentStateChanged() {
+      guard documentState.contains(.inConflict), let keyValueCRDT = keyValueCRDT else {
+        return
+      }
+      Logger.keyValueDocument.info("Handling conflict")
+      do {
+        for conflictVersion in NSFileVersion.unresolvedConflictVersionsOfItem(at: fileURL) ?? [] {
+          let tempURL = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).appendingPathExtension("kvcrdt")
+          try conflictVersion.replaceItem(at: tempURL, options: [])
+          defer {
+            try? FileManager.default.removeItem(at: tempURL)
+          }
+          let conflictQueue = try memoryDatabaseQueue(fileURL: tempURL)
+          let conflictCRDT = try KeyValueDatabase(databaseWriter: conflictQueue, authorDescription: authorDescription)
+          delegate?.keyValueDocument(self, willMergeCRDT: conflictCRDT, into: keyValueCRDT)
+          let updates = try keyValueCRDT.merge(source: conflictCRDT)
+          Logger.keyValueDocument.info("UIDocument: Merged conflict version: \(conflictVersion). Updates = \(updates)")
+          conflictVersion.isResolved = true
+          try conflictVersion.remove()
+        }
+        Logger.keyValueDocument.info("UIDocument: Finished resolving conflicts")
+        try NSFileVersion.removeOtherVersionsOfItem(at: fileURL)
+      } catch {
+        Logger.keyValueDocument.error("UIDocument: Unexpected error resolving conflict: \(error)")
+      }
     }
-    hasUnsavedChangesPipeline = keyValueCRDT.didChangePublisher().sink(receiveCompletion: { completion in
-      switch completion {
+
+    /// Creates an in-memory database queue for the contents of the file at `fileURL`
+    /// - note: If fileURL does not exist, this method returns an empty database queue.
+    /// - parameter fileURL: The file URL to read.
+    /// - returns: An in-memory database queue with the contents of fileURL.
+    func memoryDatabaseQueue(fileURL: URL) throws -> DatabaseQueue {
+      let coordinator = NSFileCoordinator(filePresenter: self)
+      var coordinatorError: NSError?
+      var result: Result<DatabaseQueue, Swift.Error>?
+      coordinator.coordinate(readingItemAt: fileURL, options: [], error: &coordinatorError) { coordinatedURL in
+        result = Result {
+          let queue = try DatabaseQueue(path: ":memory:")
+          do {
+            let didGetAccess = coordinatedURL.startAccessingSecurityScopedResource()
+            defer {
+              if didGetAccess {
+                coordinatedURL.stopAccessingSecurityScopedResource()
+              }
+            }
+            let fileQueue = try DatabaseQueue(path: coordinatedURL.path)
+            try fileQueue.backup(to: queue)
+          } catch {
+            Logger.keyValueDocument.info("Unable to load \(coordinatedURL.path): \(error)")
+          }
+          return queue
+        }
+      }
+
+      if let coordinatorError = coordinatorError {
+        throw coordinatorError
+      }
+
+      switch result {
       case .failure(let error):
-        Logger.keyValueDocument.error("Unexpected error monitoring database: \(error)")
-        assertionFailure()
-      case .finished:
-        Logger.keyValueDocument.info("Monitoring pipeline shutting down")
+        throw error
+      case .success(let dbQueue):
+        return dbQueue
+      case .none:
+        preconditionFailure()
       }
-    }, receiveValue: { [weak self] _ in
-      self?.updateChangeCount(.done)
-    })
-  }
+    }
 
-  func stopMonitoringChanges() {
-    hasUnsavedChangesPipeline?.cancel()
-    hasUnsavedChangesPipeline = nil
+    func startMonitoringChanges() {
+      guard let keyValueCRDT = keyValueCRDT else {
+        assertionFailure()
+        return
+      }
+      hasUnsavedChangesPipeline = keyValueCRDT.didChangePublisher().sink(receiveCompletion: { completion in
+        switch completion {
+        case .failure(let error):
+          Logger.keyValueDocument.error("Unexpected error monitoring database: \(error)")
+          assertionFailure()
+        case .finished:
+          Logger.keyValueDocument.info("Monitoring pipeline shutting down")
+        }
+      }, receiveValue: { [weak self] _ in
+        self?.updateChangeCount(.done)
+      })
+    }
+
+    func stopMonitoringChanges() {
+      hasUnsavedChangesPipeline?.cancel()
+      hasUnsavedChangesPipeline = nil
+    }
   }
-}
 
 #endif

--- a/Sources/KeyValueCRDT/Value.swift
+++ b/Sources/KeyValueCRDT/Value.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 
 /// The kinds of values that can be stored in the database.

--- a/Sources/KeyValueCRDT/Version.swift
+++ b/Sources/KeyValueCRDT/Version.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 
 /// A read-only snapshot of a ``Value`` at a specific point in time.
@@ -25,8 +42,8 @@ public struct Version: Equatable {
   }
 }
 
-extension Array where Element == Version {
-  public var text: String? {
+public extension Array where Element == Version {
+  var text: String? {
     get throws {
       if isEmpty {
         return nil
@@ -37,7 +54,7 @@ extension Array where Element == Version {
     }
   }
 
-  public var json: String? {
+  var json: String? {
     get throws {
       if isEmpty {
         return nil
@@ -48,7 +65,7 @@ extension Array where Element == Version {
     }
   }
 
-  public var blob: Data? {
+  var blob: Data? {
     get throws {
       if isEmpty {
         return nil
@@ -59,7 +76,7 @@ extension Array where Element == Version {
     }
   }
 
-  public var isDeleted: Bool {
+  var isDeleted: Bool {
     get throws {
       if isEmpty {
         return false // "deleted" is different from "doesn't exist"

--- a/Sources/KeyValueCRDT/VersionVector.swift
+++ b/Sources/KeyValueCRDT/VersionVector.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 
 struct VersionVector<Key, Value> where Key: Hashable, Value: Comparable {
@@ -97,10 +114,10 @@ extension VersionVector where Key == AuthorVersionIdentifier, Value == Int {
   /// Construct a VersionVector with the contents of the Author table.
   /// - precondition: Each `id` in `records` must be unique.
   init(_ records: [AuthorRecord]) {
-    self.versions = Dictionary(uniqueKeysWithValues: records.map({ (key: AuthorVersionIdentifier($0), value: $0.usn) }))
+    self.versions = Dictionary(uniqueKeysWithValues: records.map { (key: AuthorVersionIdentifier($0), value: $0.usn) })
   }
 
   init(_ tuples: [(key: UUID, value: Int)]) {
-    self.versions = Dictionary(uniqueKeysWithValues: tuples.map({ (key: AuthorVersionIdentifier($0.key), value: $0.value) }))
+    self.versions = Dictionary(uniqueKeysWithValues: tuples.map { (key: AuthorVersionIdentifier($0.key), value: $0.value) })
   }
 }

--- a/Sources/kvcrdt/Table.swift
+++ b/Sources/kvcrdt/Table.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 
 struct Table<T>: CustomStringConvertible {

--- a/Sources/kvcrdt/main.swift
+++ b/Sources/kvcrdt/main.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import ArgumentParser
 import Foundation
 import KeyValueCRDT
@@ -25,10 +42,10 @@ struct Statistics: ParsableCommand {
     let crdt = try KeyValueDatabase(fileURL: fileURL, author: Author(id: UUID(), name: "temp"))
     let stats = try crdt.statistics
     let output = """
-Entries:    \(stats.entryCount)
-Tombstones: \(stats.tombstoneCount)
-Authors:    \(stats.authorCount)
-"""
+    Entries:    \(stats.entryCount)
+    Tombstones: \(stats.tombstoneCount)
+    Authors:    \(stats.authorCount)
+    """
     print(output)
     if !stats.authorTableIsConsistent {
       print("\n\nWARNING: The author table is not consistent with the entries; merges to/from this database will not work.")

--- a/Tests/KeyValueCRDTTests/ApplicationIdentifier+Tests.swift
+++ b/Tests/KeyValueCRDTTests/ApplicationIdentifier+Tests.swift
@@ -1,4 +1,19 @@
-// 
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
 
 import Foundation
 import KeyValueCRDT

--- a/Tests/KeyValueCRDTTests/ApplicationIdentifier+Tests.swift
+++ b/Tests/KeyValueCRDTTests/ApplicationIdentifier+Tests.swift
@@ -1,0 +1,11 @@
+// 
+
+import Foundation
+import KeyValueCRDT
+
+internal extension ApplicationIdentifier {
+  static let tests = ApplicationIdentifier(id: "org.brians-brain.KeyValueCRDTTests", majorVersion: 1, minorVersion: 0)
+  static let testsV2 = ApplicationIdentifier(id: "org.brians-brain.KeyValueCRDTTests", majorVersion: 2, minorVersion: 0)
+  static let testsV21 = ApplicationIdentifier(id: "org.brians-brain.KeyValueCRDTTests", majorVersion: 2, minorVersion: 1)
+  static let differentApplication = ApplicationIdentifier(id: "org.brians-brain.dreaming", majorVersion: 13, minorVersion: 0)
+}

--- a/Tests/KeyValueCRDTTests/GenericUpgrader.swift
+++ b/Tests/KeyValueCRDTTests/GenericUpgrader.swift
@@ -1,4 +1,19 @@
-// 
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
 
 import Foundation
 import KeyValueCRDT

--- a/Tests/KeyValueCRDTTests/GenericUpgrader.swift
+++ b/Tests/KeyValueCRDTTests/GenericUpgrader.swift
@@ -1,0 +1,18 @@
+// 
+
+import Foundation
+import KeyValueCRDT
+
+internal struct GenericUpgrader: ApplicationDataUpgrader {
+  let expectedApplicationIdentifier: ApplicationIdentifier
+  let upgradeBlock: (() -> Void)?
+
+  init(_ applicationIdentifier: ApplicationIdentifier, upgradeBlock: (() -> Void)? = nil) {
+    self.expectedApplicationIdentifier = applicationIdentifier
+    self.upgradeBlock = upgradeBlock
+  }
+
+  func upgradeApplicationData(in database: KeyValueDatabase) throws {
+    upgradeBlock?()
+  }
+}

--- a/Tests/KeyValueCRDTTests/KeyValueCRDTTests.swift
+++ b/Tests/KeyValueCRDTTests/KeyValueCRDTTests.swift
@@ -547,20 +547,6 @@ private struct UpgradeToV2: ApplicationDataUpgrader {
   }
 }
 
-private struct GenericUpgrader: ApplicationDataUpgrader {
-  let expectedApplicationIdentifier: ApplicationIdentifier
-  let upgradeBlock: (() -> Void)?
-
-  init(_ applicationIdentifier: ApplicationIdentifier, upgradeBlock: (() -> Void)? = nil) {
-    self.expectedApplicationIdentifier = applicationIdentifier
-    self.upgradeBlock = upgradeBlock
-  }
-
-  func upgradeApplicationData(in database: KeyValueDatabase) throws {
-    upgradeBlock?()
-  }
-}
-
 private struct DifferentApplicationUpgrader: ApplicationDataUpgrader {
   let expectedApplicationIdentifier: ApplicationIdentifier = .differentApplication
 
@@ -579,11 +565,4 @@ private extension String {
   static let alice = "Alice"
   static let bob = "Bob"
   static let charlie = "Charlie"
-}
-
-private extension ApplicationIdentifier {
-  static let tests = ApplicationIdentifier(applicationIdentifier: "org.brians-brain.KeyValueCRDTTests", majorVersion: 1, minorVersion: 0)
-  static let testsV2 = ApplicationIdentifier(applicationIdentifier: "org.brians-brain.KeyValueCRDTTests", majorVersion: 2, minorVersion: 0)
-  static let testsV21 = ApplicationIdentifier(applicationIdentifier: "org.brians-brain.KeyValueCRDTTests", majorVersion: 2, minorVersion: 1)
-  static let differentApplication = ApplicationIdentifier(applicationIdentifier: "org.brians-brain.dreaming", majorVersion: 13, minorVersion: 0)
 }

--- a/Tests/KeyValueCRDTTests/KeyValueCRDTTests.swift
+++ b/Tests/KeyValueCRDTTests/KeyValueCRDTTests.swift
@@ -1,8 +1,25 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Combine
 import Foundation
+import GRDB
 import KeyValueCRDT
 import XCTest
-import GRDB
 
 final class KeyValueCRDTTests: XCTestCase {
   func testSimpleStorage() throws {
@@ -414,7 +431,7 @@ final class KeyValueCRDTTests: XCTestCase {
 
     // In contrast, `updatedValuesPublisher` is "cold". It publishes only values that change after they change.
     let updatedValueExpectation = expectation(description: "updated value publisher")
-    let valuesSubscription = alice.updatedValuesPublisher.sink { (scopedKey, versions) in
+    let valuesSubscription = alice.updatedValuesPublisher.sink { scopedKey, versions in
       XCTAssertEqual(scopedKey, "key2")
       XCTAssertEqual(try! versions.text, "updated")
       updatedValueExpectation.fulfill()
@@ -439,7 +456,7 @@ final class KeyValueCRDTTests: XCTestCase {
     let sharedKeyExpectation = expectation(description: "shared key")
     let soloKeyExpectation = expectation(description: "solo key")
 
-    let subscription = alice.updatedValuesPublisher.sink { (scopedKey, versions) in
+    let subscription = alice.updatedValuesPublisher.sink { scopedKey, versions in
       if scopedKey == "shared" {
         sharedKeyExpectation.fulfill()
       }
@@ -504,7 +521,7 @@ final class KeyValueCRDTTests: XCTestCase {
 
   func testCanOpenWithMinorDifference() throws {
     let storage = try DatabaseQueue(path: ":memory:")
-    let _ = try KeyValueDatabase(databaseWriter: storage, authorDescription: .alice, upgrader: GenericUpgrader(.testsV21))
+    _ = try KeyValueDatabase(databaseWriter: storage, authorDescription: .alice, upgrader: GenericUpgrader(.testsV21))
     var didUpgrade = false
     let v2database = try KeyValueDatabase(databaseWriter: storage, authorDescription: .bob, upgrader: GenericUpgrader(.testsV2, upgradeBlock: { didUpgrade = true }))
     XCTAssertFalse(didUpgrade)

--- a/Tests/KeyValueCRDTTests/UIKeyValueDocumentTests.swift
+++ b/Tests/KeyValueCRDTTests/UIKeyValueDocumentTests.swift
@@ -1,3 +1,20 @@
+//  Licensed to the Apache Software Foundation (ASF) under one
+//  or more contributor license agreements.  See the NOTICE file
+//  distributed with this work for additional information
+//  regarding copyright ownership.  The ASF licenses this file
+//  to you under the Apache License, Version 2.0 (the
+//  "License"); you may not use this file except in compliance
+//  with the License.  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing,
+//  software distributed under the License is distributed on an
+//  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+//  KIND, either express or implied.  See the License for the
+//  specific language governing permissions and limitations
+//  under the License.
+
 import Foundation
 import KeyValueCRDT
 import XCTest


### PR DESCRIPTION
This PR adds the concept of "application data versioning." You are **STRONGLY** encouraged to add an application identifier and application version to file formats built with KeyValueCRDT. This will prevent old versions of your software from corrupting data written by new versions of your software.